### PR TITLE
Properly throw deserializer errors

### DIFF
--- a/PocketSharp/PocketClient.cs
+++ b/PocketSharp/PocketClient.cs
@@ -372,7 +372,13 @@ namespace PocketSharp
         }
       );
 
-      if (errors.Count > 0)
+      if (errors.Count == 1)
+      {
+        PocketException firstException = errors[0];
+        firstException.Data["json"] = json;
+        throw firstException;
+      }
+      else if (errors.Count > 1)
       {
         AggregateException ex = new AggregateException("Unable to parse json. See innner exceptions and exception.Data[\"json\"] for details", errors);
         ex.Data["json"] = json;


### PR DESCRIPTION
If exceptions are thrown within the Error handler, they will ultimately be thrown as

> System.InvalidOperationException: Current error context error is different to requested error

According to the example on the [Newtonsoft.Json website](https://www.newtonsoft.com/json/help/html/serializationerrorhandling.htm) errors should be captured, marked as Handled, then accessed _after_ the deserializing process.

This will provide accurate error feedback to users of this library and prevent confusion like in #44